### PR TITLE
Github Pages gem 으로 변경

### DIFF
--- a/install-mac.sh
+++ b/install-mac.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew install ruby
-sudo gem install jekyll rdiscount
+sudo gem install github-pages
 echo "You can run the server by using 'jekyll serve'."


### PR DESCRIPTION
기존 설치 방식은 [Jekyll](http://jekyllrb.com)이 3.0으로 업그레이드됨에 따라 호환성 문제로 정상적인 실행이 되지 않습니다. 기술블로그를 업데이트하면 가능하지만 어차피 Github Pages가 2.4.0을 쓰므로 의미가 없습니다. 이에 설치 스크립트가 [Github Pages gem](https://github.com/github/pages-gem)을 설치하도록 고칩니다.
